### PR TITLE
Not Conformant?

### DIFF
--- a/licenses/uk-ogl.json
+++ b/licenses/uk-ogl.json
@@ -4,7 +4,7 @@
   "domain_software": false, 
   "family": "", 
   "id": "uk-ogl", 
-  "is_okd_compliant": true, 
+  "is_okd_compliant": false, 
   "is_osi_compliant": false, 
   "maintainer": "", 
   "status": "active", 


### PR DESCRIPTION
I believe it was decided that the UK-OGL was not conformant in its current version due to the constraints it imposes beyond the two that the definition specifies.
