### PR TITLE
Added description of unlicense

### DIFF
--- a/licenses/unlicense.json
+++ b/licenses/unlicense.json
@@ -1,0 +1,13 @@
+{
+  "domain_content": false, 
+  "domain_data": false, 
+  "domain_software": true, 
+  "family": "", 
+  "id": "unlicense", 
+  "is_okd_compliant": true, 
+  "is_osi_compliant": false, 
+  "maintainer": "", 
+  "status": "active", 
+  "title": "The Unlicense", 
+  "url": "http://unlicense.org/"
+}


### PR DESCRIPTION
This fixes #9. I _think_ I've got the description right: doesn't seem to be appropriate for general copyright or cover database right, and isn't listed as OSI approved.
