### PR TITLE
UK-OGL License also applies to software

### DIFF
--- a/licenses/uk-ogl.json
+++ b/licenses/uk-ogl.json
@@ -1,7 +1,7 @@
 {
   "domain_content": true, 
   "domain_data": true, 
-  "domain_software": false, 
+  "domain_software": true, 
   "family": "", 
   "id": "uk-ogl", 
   "is_okd_compliant": false, 


### PR DESCRIPTION
The UK-OGL license is also applicable to the software domain.

See notes here:

http://www.nationalarchives.gov.uk/information-management/government-licensing/what-ogl-covers.htm

and:

http://www.nationalarchives.gov.uk/information-management/government-licensing/licensing-software.htm
