### PR TITLE
Adding new license -  Geogratis

### DIFF
--- a/licenses/geogratis.json
+++ b/licenses/geogratis.json
@@ -3,7 +3,7 @@
   "domain_data": true,
   "domain_software": false,
   "family": "",
-  "id": "gg",
+  "id": "geogratis",
   "od_conformance": "",
   "osd_conformance": "not reviewed",
   "maintainer": "",

--- a/licenses/gg.json
+++ b/licenses/gg.json
@@ -1,0 +1,13 @@
+{
+  "domain_content": false,
+  "domain_data": true,
+  "domain_software": false,
+  "family": "",
+  "id": "gg",
+  "od_conformance": "",
+  "osd_conformance": "not reviewed",
+  "maintainer": "",
+  "status": "active",
+  "title": "Geogratis",
+  "url": "http://geogratis.gc.ca/geogratis/licenceGG"
+}


### PR DESCRIPTION
In [Datahub's](http://datahub.io),  i have spotted datasets with these two licenses that are not available in the current list.

```
geogratis: 
   [ 'CanMatrix - Print Ready, Digital Topographic Maps of Canada | CanMatrix - Prêt à imprimer, Données topographiques numériques matricielles du Canada',
     'Atlas of Canada 1,000,000 National Frameworks Data, Hydrology - Dams',
     'Atlas of Canada 1,000,000 National Frameworks Data, Hydrology  Drainage Areas',
     'Atlas of Canada 1,000,000 National Frameworks Data, Hydrology - Drainage Network',
     'Atlas of Canada 1,000,000 National Frameworks Data, Protected Areas',
     'Atlas of Canada 1,000,000 National Frameworks Data, Rail Network',
     'Atlas of Canada 1,000,000 National Frameworks Data, Road Network',
     'AVHRR Land Cover Data, Canada',
     'Bi-directional reflectance properties of the land surface over Canada derived from MODIS multispectral observations at 1-km spatial resolution. 2000-2004',
     'Canada 1-km, 10-day, SPOT/VEGETATION composites for growing season 1998-2004',
     'Canada3D - Digital Elevation Model of the Canadian Landmass',
     'Canada Land Inventory (1:50 000) - City Land Capability for Agriculture',
     'Canada Land Inventory (1:50 000) - City Land Capability for Recreation',
     'Canada Land Inventory (1:50 000) - Land Capability for Agriculture',
     'Canada Land Inventory - Land Capability for Waterfowl',
     'Geogratis - Canada-wide 1-km AVHRR Composite Maps based on GEOCOMP Data',
     'Geogratis - AVHRR Land Cover Data, Canada',
     'Geogratis - Canada Land Inventory - Land Capability for Agriculture',
     'Geogratis - Canada Land Inventory - Land Capability for Forestry',
     'Geogratis - Land Capability for Agriculture - Canada Land Inventory (1:50 000)',
     'Geogratis - Land Use (circa 1966) - Canada Land Inventory (1:50 000)',
     'Geogratis - Land Capability for Recreation - Canada Land Inventory (1:50 000)',
     'Geogratis - Canada Land Inventory - 1966 Land Use',
     'Geogratis - Canada Land Inventory - Sport Fish Capability',
     'Geogratis - Canada Land Inventory - Land Capability for Ungulates',
     'Geogratis - Canada Land Inventory - Land Capability for Waterfowl',
     'Geogratis - CanImage Collection',
     'Geobase/Geogratis - CanMatrix Collection',
     'Geogratis - 1996 Population (Ecumene) Census Data Collection',
     'Geogratis - City Land Capability for Agriculture - Canada Land Inventory 1:50k',
     'Geogratis - City Land Capability for Recreation - Canada Land Inventory 1:50k',
     'Geogratis - British Columbia Mainland Mosaic',
     'North American Atlas - Railroads Collection',
     'North American Atlas - Roads Collection',
     'North American Atlas - Sea Ice Collection',
     'Geogratis - Radarsat Mosaic of Canada Collection',
     'Geogratis - Vector Map Level 0 (VMAP0) Product Canada Collection',
     'Geogratis - 1-km Water Fraction From National Topographic Data Base Maps, Canada',
     'Tactile Atlas of Canada; Thematic Tactile Atlas of Canada',
     'The State of Canada\'s Ecosystems in Maps',
     'Toporama',
     'Vector Indexes of the National Topographic System of Canada',
     'Vector Map Level 0 (VMAP0) Product Canada' ]
```

```
'canada-crown': 
   [ 'Canadian Climate Data Online ',
     'Gridded climate data for 1961-90 and scenarios for 2010-39 and 2040-69 periods',
     'Licensed Natural Health Product Database (LNHPD) Data Extract',
     'Canadian Nutrient File',
     'Chronic Disease Infobase',
     'Directory of Federal Real Property' ],
  W3C: [ 'Голая правда о знаменитостях', 'namespace' ]
```

