### PR TITLE
ukcrown licenses are retired

### DIFF
--- a/licenses/ukcrown-withrights.json
+++ b/licenses/ukcrown-withrights.json
@@ -7,7 +7,7 @@
   "od_conformance": "approved", 
   "osd_conformance": "not reviewed", 
   "maintainer": "", 
-  "status": "active", 
+  "status": "retired", 
   "title": "UK Crown Copyright with data.gov.uk rights", 
   "url": ""
 }


### PR DESCRIPTION
The UK Open Government License (OGL) has replaced this and other licenses