### PR TITLE
UK Click Use PSI has been retired

### DIFF
--- a/licenses/ukclickusepsi.json
+++ b/licenses/ukclickusepsi.json
@@ -7,7 +7,7 @@
   "od_conformance": "rejected", 
   "osd_conformance": "not reviewed", 
   "maintainer": "", 
-  "status": "active", 
+  "status": "retired", 
   "title": "UK Click Use PSI", 
   "url": ""
 }


### PR DESCRIPTION
The UK Open Government License (OGL) has replaced this and other licenses.
http://www.opsi.gov.uk/psi/