### PR TITLE
geogratis is clearly retired

### DIFF
--- a/licenses/geogratis.json
+++ b/licenses/geogratis.json
@@ -7,7 +7,7 @@
   "od_conformance": "",
   "osd_conformance": "not reviewed",
   "maintainer": "",
-  "status": "active",
+  "status": "retired",
   "title": "Geogratis",
   "url": "http://geogratis.gc.ca/geogratis/licenceGG"
 }

--- a/licenses/groups/all.json
+++ b/licenses/groups/all.json
@@ -1319,7 +1319,7 @@
     "maintainer": "",
     "od_conformance": "",
     "osd_conformance": "not reviewed",
-    "status": "active",
+    "status": "reitred",
     "title": "Geogratis",
     "url": "http://geogratis.gc.ca/geogratis/licenceGG"
   },

--- a/licenses/jsonp/all.js
+++ b/licenses/jsonp/all.js
@@ -1319,7 +1319,7 @@ license_callback({
     "maintainer": "",
     "od_conformance": "",
     "osd_conformance": "not reviewed",
-    "status": "active",
+    "status": "reitred",
     "title": "Geogratis",
     "url": "http://geogratis.gc.ca/geogratis/licenceGG"
   },

--- a/licenses/jsonp/geogratis.js
+++ b/licenses/jsonp/geogratis.js
@@ -7,7 +7,8 @@ license_callback({
   "od_conformance": "",
   "osd_conformance": "not reviewed",
   "maintainer": "",
-  "status": "active",
+  "status": "reitred",
   "title": "Geogratis",
   "url": "http://geogratis.gc.ca/geogratis/licenceGG"
-});
+}
+);


### PR DESCRIPTION
licenses.csv says it is
http://geogratis.gc.ca/geogratis/licenceGG obtains 404 and is not available at web.archive.org
404 message points to new home page at https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/11042
new home page links to https://www.nrcan.gc.ca/earth-sciences/geography/topographic-information/free-data-geogratis/licence/17285
which links to OGL-Canada-2.0